### PR TITLE
Toggle quotes correctly for multiline strings

### DIFF
--- a/lib/toggle-quotes.coffee
+++ b/lib/toggle-quotes.coffee
@@ -1,42 +1,144 @@
 toggleQuotes = (editor) ->
   editor.transact ->
+    lineTokens = tokenizeLines(editor)
+    stringLimitTokens = findQuotedStringStartAndEndTokens(lineTokens)
+
     for cursor in editor.getCursors()
       position = cursor.getBufferPosition()
-      toggleQuoteAtPosition(editor, position)
+      toggleQuoteAtPosition(editor, position, stringLimitTokens)
       cursor.setBufferPosition(position)
 
-toggleQuoteAtPosition = (editor, position) ->
-  range = editor.displayBuffer.bufferRangeForScopeAtPosition('.string.quoted', position)
+toggleQuoteAtPosition = (editor, position, stringLimitTokens) ->
+  quotedStringRangeTokens = findQuotedStringRangeTokens(stringLimitTokens, position)
 
-  unless range?
+  if quotedStringRangeTokens
+    start = [quotedStringRangeTokens[0].row, quotedStringRangeTokens[0].column]
+    end = [quotedStringRangeTokens[1].row, quotedStringRangeTokens[1].column + quotedStringRangeTokens[1].bufferDelta]
+    range = [start, end]
+
+    # In Python a string can have a prefix specifying its format. The Python
+    # grammar includes this prefix in the string, and thus we need to exclude
+    # it when toggling quotes
+    startRegex = new RegExp("""^([uUr]?)(["']+)""")
+    matches = quotedStringRangeTokens[0].value.match(startRegex)
+    if matches
+      text = editor.getTextInBufferRange(range)
+      prefix = matches[1] or ""
+      quoteString = matches[2]
+      quoteCharacter = quoteString[0]
+    else
+      # Will only happen if the string doesn't start with " or '
+      range = null
+
+  if not range?
     # Attempt to match the current invalid region if it is wrapped in quotes
     # This is useful for languages where changing the quotes makes the range
     # invalid and so toggling again should properly restore the valid quotes
     if range = editor.displayBuffer.bufferRangeForScopeAtPosition('.invalid.illegal', position)
       return unless /^(".*"|'.*')$/.test(editor.getTextInBufferRange(range))
 
+      text = editor.getTextInBufferRange(range)
+      prefix = ''
+      [quoteCharacter] = text
+      quoteString = quoteCharacter
+
   return unless range?
 
-  text = editor.getTextInBufferRange(range)
-  [quoteCharacter] = text
-
-  # In Python a string can have a prefix specifying its format. The Python
-  # grammar includes this prefix in the string, and thus we need to exclude
-  # it when toggling quotes
-  prefix = ''
-  [prefix, quoteCharacter] = text if /[uUr]/.test(quoteCharacter)
-
-  oppositeQuoteCharacter = getOppositeQuote(quoteCharacter)
   quoteRegex = new RegExp(quoteCharacter, 'g')
-  escapedQuoteRegex = new RegExp("\\\\#{quoteCharacter}", 'g')
-  oppositeQuoteRegex = new RegExp(oppositeQuoteCharacter, 'g')
+  oppositeQuoteCharacter = getOppositeQuote(quoteCharacter)
+  oppositeQuoteString = quoteString.replace(quoteRegex, oppositeQuoteCharacter)
 
-  newText = text
-    .replace(oppositeQuoteRegex, "\\#{oppositeQuoteCharacter}")
-    .replace(escapedQuoteRegex, quoteCharacter)
-  newText = prefix + oppositeQuoteCharacter + newText[(1+prefix.length)...-1] + oppositeQuoteCharacter
+  innerText = text[(prefix.length + oppositeQuoteString.length)...-(oppositeQuoteString.length)]
+
+  # If quoteString is " (and oppositeQuoteString is '), we want to replace
+  # all ' in the text with \' (we must escape it now), and all \" with "
+  # (no need to escape any more)
+
+  # Likewise, if quoteString is """ (and oppositeQuoteString is '''), we want to replace all '''
+  # in the text with \'\'\' (we must escape it), and all \"\"\" with """ (no need to escape any
+  # more). We can ignore Single or double " and '
+
+  escapedQuoteRegex = new RegExp(("\\\\#{c}" for c in quoteString).join(''), 'g')
+  oppositeQuoteRegex = new RegExp(oppositeQuoteString, 'g')
+  escapedOppositeQuoteString = ("\\#{c}" for c in oppositeQuoteString).join('')
+
+  innerText = innerText
+    .replace(oppositeQuoteRegex, escapedOppositeQuoteString)
+    .replace(escapedQuoteRegex, quoteString)
+
+  newText = prefix + oppositeQuoteString + innerText + oppositeQuoteString
 
   editor.setTextInBufferRange(range, newText)
+
+tokenizeLines = (editor) ->
+  grammar = editor.getGrammar()
+  lineTokens = grammar.tokenizeLines(editor.getText())
+
+  # Mark each token with its position in the buffer
+  row = 0
+  for line in lineTokens
+    column = 0
+    for token in line
+      token.row = row
+      token.column = column
+      column += token.bufferDelta
+    row += 1
+
+  lineTokens
+
+findQuotedStringStartAndEndTokens = (lineTokens) ->
+  return [] if not lineTokens
+
+  # Find and categorize all quoted string start and end tokens
+  stringLimitTokens = []
+  for line in lineTokens
+    for token in line
+      for scope in token.scopeDescriptor
+        if scope.indexOf(".string.begin") != -1
+          token.stringLimitType = 'start'
+          stringLimitTokens.push token
+        if scope.indexOf(".string.end") != -1
+          token.stringLimitType = 'end'
+          stringLimitTokens.push token
+
+  return stringLimitTokens
+
+findQuotedStringRangeTokens = (stringLimitTokens, position) ->
+  # If there aren't any string tokens, there isn't a valid range
+  if not stringLimitTokens
+    return null
+
+  prePositionTokens = stringLimitTokens.filter (token) ->
+    if token.row < position.row or (token.row == position.row and (token.column + token.bufferDelta) < position.column)
+      # The token is cleary before the position
+      return true
+    if token.row == position.row and token.column < position.column
+      # The position is *on the token*
+      return token.stringLimitType == 'start'
+    return false
+
+  postPositionTokens = stringLimitTokens.filter (token) ->
+    if token.row > position.row or (token.row == position.row and token.column >= position.column)
+      # The token is cleary after the position
+      return true
+    if token.row == position.row and token.column < position.column and (token.column + token.bufferDelta) > position.column
+      # The position is *on the token*
+      return token.stringLimitType == 'end'
+    return false
+
+  [..., lastPrePositionToken] = prePositionTokens
+  if not lastPrePositionToken or lastPrePositionToken.stringLimitType != 'start'
+    # The string limit token closest before the position must be a start token
+    # for the position to be in the range of a quoted string
+    return null
+
+  [firstPostPositionToken] = postPositionTokens
+  if not firstPostPositionToken or firstPostPositionToken.stringLimitType != 'end'
+    # The string limit token closest after the position must be an end token
+    # for the position to be in the range of a quoted string
+    return null
+
+  [lastPrePositionToken, firstPostPositionToken]
 
 getOppositeQuote = (quoteCharacter) ->
   if quoteCharacter is '"'

--- a/spec/toggle-quotes-spec.coffee
+++ b/spec/toggle-quotes-spec.coffee
@@ -112,6 +112,7 @@ describe "ToggleQuotes", ->
         editor.setText """
           print(u"Hello World")
           print(r'')
+          print(u'''Hello there''')
         """
         editor.setGrammar(atom.syntax.selectGrammar('test.py'))
 
@@ -128,3 +129,243 @@ describe "ToggleQuotes", ->
         toggleQuotes(editor)
         expect(editor.lineForBufferRow(1)).toBe 'print(r"")'
         expect(editor.getCursorBufferPosition()).toEqual [1, 8]
+
+    describe "when cursor is inside a single quoted unicode multiline string", ->
+      it "switches quotes to double excluding unicode character", ->
+        editor.setCursorBufferPosition([2, 16])
+        toggleQuotes(editor)
+        expect(editor.lineForBufferRow(2)).toBe '''print(u"""Hello there""")'''
+        expect(editor.getCursorBufferPosition()).toEqual [2, 16]
+
+  describe "toggleQuotes(editor) coffeescript", ->
+    editor = null
+
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('language-coffee-script')
+
+      runs ->
+        editor = atom.project.openSync()
+        editor.setGrammar(atom.syntax.selectGrammar('test.coffee'))
+
+    describe "when cursor is inside a double quoted block single line string", ->
+      beforeEach ->
+        editor.setText '''
+          console.log("""Hello World""")
+          console.log("""Hello 'World'""")
+          console.log("""Hello \'\'\'World\'\'\'""")
+          console.log("""""")
+        '''
+
+      it "switches quotes to single", ->
+        editor.setCursorBufferPosition([0, 14])
+        toggleQuotes(editor)
+        expect(editor.lineForBufferRow(0)).toBe """console.log('''Hello World''')"""
+        expect(editor.getCursorBufferPosition()).toEqual [0, 14]
+
+      it "switches quotes to single but does not escape single single quotes", ->
+        editor.setCursorBufferPosition([1, 14])
+        toggleQuotes(editor)
+        expect(editor.lineForBufferRow(1)).toBe """console.log('''Hello 'World'''')"""
+        expect(editor.getCursorBufferPosition()).toEqual [1, 14]
+
+      it "switches quotes to single and escapes three single quotes", ->
+        editor.setCursorBufferPosition([2, 14])
+        toggleQuotes(editor)
+        expect(editor.lineForBufferRow(2)).toBe """console.log('''Hello \\'\\'\\'World\\'\\'\\'''')"""
+        expect(editor.getCursorBufferPosition()).toEqual [2, 14]
+
+      describe "which is empty", ->
+        it "switches quotes to single when cursor is inside string", ->
+          editor.setCursorBufferPosition([3, 15])
+          toggleQuotes(editor)
+          expect(editor.lineForBufferRow(3)).toBe """console.log('''''')"""
+          expect(editor.getCursorBufferPosition()).toEqual [3, 15]
+
+        it "switches quotes to single when cursor is inside start quotes", ->
+          editor.setCursorBufferPosition([3, 13])
+          toggleQuotes(editor)
+          expect(editor.lineForBufferRow(3)).toBe """console.log('''''')"""
+          expect(editor.getCursorBufferPosition()).toEqual [3, 13]
+
+        it "switches quotes to single when cursor is inside end quotes", ->
+          editor.setCursorBufferPosition([3, 16])
+          toggleQuotes(editor)
+          expect(editor.lineForBufferRow(3)).toBe """console.log('''''')"""
+          expect(editor.getCursorBufferPosition()).toEqual [3, 16]
+
+    describe "when cursor is inside a single quoted block single line string", ->
+      beforeEach ->
+        editor.setText """
+          console.log('''Hello World''')
+          console.log('''Hello "World"''')
+          console.log('''Hello \"\"\"World\"\"\"''')
+        """
+
+      it "switches quotes to double", ->
+        editor.setCursorBufferPosition([0, 14])
+        toggleQuotes(editor)
+        expect(editor.lineForBufferRow(0)).toBe '''console.log("""Hello World""")'''
+        expect(editor.getCursorBufferPosition()).toEqual [0, 14]
+
+      it "switches quotes to double but does not escape double single quotes", ->
+        editor.setCursorBufferPosition([1, 14])
+        toggleQuotes(editor)
+        expect(editor.lineForBufferRow(1)).toBe '''console.log("""Hello "World"""")'''
+        expect(editor.getCursorBufferPosition()).toEqual [1, 14]
+
+      it "switches quotes to double and escapes three double quotes", ->
+        editor.setCursorBufferPosition([2, 14])
+        toggleQuotes(editor)
+        expect(editor.lineForBufferRow(2)).toBe '''console.log("""Hello \\"\\"\\"World\\"\\"\\"""")'''
+        expect(editor.getCursorBufferPosition()).toEqual [2, 14]
+
+    describe "when cursor is inside a double quoted multiline block string", ->
+      describe "with one line of text", ->
+        beforeEach ->
+          editor.setText '''
+            console.log("""
+              Hello World
+            """)
+          '''
+        it "switches quotes to single", ->
+          editor.setCursorBufferPosition([1, 8])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe """
+            console.log('''
+              Hello World
+            ''')
+          """
+          expect(editor.getCursorBufferPosition()).toEqual [1, 8]
+
+      describe "with no lines", ->
+        beforeEach ->
+          editor.setText '''
+            console.log("""
+            """)
+          '''
+        it "switches quotes to single", ->
+          editor.setCursorBufferPosition([1, 1])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe """
+            console.log('''
+            ''')
+          """
+          expect(editor.getCursorBufferPosition()).toEqual [1, 1]
+
+      describe "with multiple empty lines", ->
+        beforeEach ->
+          editor.setText '''
+            console.log("""
+
+
+            """)
+          '''
+        it "switches quotes to single", ->
+          editor.setCursorBufferPosition([1, 0])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe """
+            console.log('''
+
+
+            ''')
+          """
+          expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+      describe "with multiple lines of content", ->
+        beforeEach ->
+          editor.setText '''
+            console.log("""
+              Hello there,
+
+              'World!'
+              "this is the real life"
+
+            """)
+          '''
+        it "switches quotes to single", ->
+          editor.setCursorBufferPosition([1, 3])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe """
+            console.log('''
+              Hello there,
+
+              'World!'
+              "this is the real life"
+
+            ''')
+          """
+          expect(editor.getCursorBufferPosition()).toEqual [1, 3]
+
+    describe "when cursor is inside a double quoted multiline string", ->
+      describe "with one line of text", ->
+        beforeEach ->
+          editor.setText '''
+            console.log("
+              Hello World
+            ")
+          '''
+        it "switches quotes to single", ->
+          editor.setCursorBufferPosition([1, 8])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe """
+            console.log('
+              Hello World
+            ')
+          """
+          expect(editor.getCursorBufferPosition()).toEqual [1, 8]
+
+      describe "with no lines", ->
+        beforeEach ->
+          editor.setText '''
+            console.log("
+            ")
+          '''
+        it "switches quotes to single", ->
+          editor.setCursorBufferPosition([1, 0])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe """
+            console.log('
+            ')
+          """
+          expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+  describe "toggleQuotes(editor) html", ->
+    editor = null
+
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('language-html')
+      waitsForPromise ->
+        atom.packages.activatePackage('language-javascript')
+
+      runs ->
+        editor = atom.project.openSync()
+        editor.setText """
+          <script type="test/javascript">
+          var x = "asdfasdf";
+          </script>
+        """
+        editor.setGrammar(atom.syntax.selectGrammar('test.html'))
+
+    describe "when cursor is inside a double quoted html string", ->
+      it "switches quotes to single", ->
+        editor.setCursorBufferPosition([0, 16])
+        toggleQuotes(editor)
+        expect(editor.getText()).toBe """
+          <script type='test/javascript'>
+          var x = "asdfasdf";
+          </script>
+        """
+        expect(editor.getCursorBufferPosition()).toEqual [0, 16]
+
+    describe "when cursor is inside a double quoted embedded javascript string", ->
+      it "switches quotes to single", ->
+        editor.setCursorBufferPosition([1, 10])
+        toggleQuotes(editor)
+        expect(editor.getText()).toBe """
+          <script type="test/javascript">
+          var x = 'asdfasdf';
+          </script>
+        """
+        expect(editor.getCursorBufferPosition()).toEqual [1, 10]


### PR DESCRIPTION
This pull request enables string quote toggling for multiline strings, and fixes it to work properly with "block strings" / "heredocs" - those starting with `"""` or `'''`.

This fixes #5.

I tried to make it as readable as possible, but sorry for the huge diff. There are tests covering all the cases I can think of.

Toggling works for all these CoffeeScript strings (and multiline / heredoc strings in other languages):

```coffee-script
"

asdfasdf



"

"""
asdfasdfa
"""


"""
'hi!'

'''adam'''
"""

""""""

"'hi'"

console.log('''
''')

console.log("""




""")

```