### PR TITLE
Make quote characters configurable

### DIFF
--- a/lib/toggle-quotes.coffee
+++ b/lib/toggle-quotes.coffee
@@ -41,10 +41,10 @@ toggleQuoteAtPosition = (editor, position) ->
 
   editor.setTextInBufferRange(range, newText)
 
-getNextQuoteCharacter = (quoteCharacter, quoteCharacters) ->
-  i = quoteCharacters.indexOf(quoteCharacter)
+getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) ->
+  i = allQuoteCharacters.indexOf(quoteCharacter)
   return null if i == -1
-  quoteCharacters[(i + 1) % quoteCharacters.length]
+  allQuoteCharacters[(i + 1) % allQuoteCharacters.length]
 
 module.exports =
   config:

--- a/lib/toggle-quotes.coffee
+++ b/lib/toggle-quotes.coffee
@@ -15,8 +15,7 @@ toggleQuoteAtPosition = (editor, position) ->
     # invalid and so toggling again should properly restore the valid quotes
     if range = editor.displayBuffer.bufferRangeForScopeAtPosition('.invalid.illegal', position)
       inner = quoteChars.split('').map((c) -> "#{c}.*#{c}").join('|')
-      regex = new RegExp("^(#{inner})$", 'g')
-      return unless regex.test(editor.getTextInBufferRange(range))
+      return unless ///^(#{inner})$///g.test(editor.getTextInBufferRange(range))
 
   return unless range?
 

--- a/lib/toggle-quotes.coffee
+++ b/lib/toggle-quotes.coffee
@@ -28,7 +28,7 @@ toggleQuoteAtPosition = (editor, position) ->
   prefix = ''
   [prefix, quoteCharacter] = text if /[uUr]/.test(quoteCharacter)
 
-  nextQuoteCharacter = getNextQuote(quoteCharacter, quoteChars)
+  nextQuoteCharacter = getNextQuoteCharacter(quoteCharacter, quoteChars)
   return unless nextQuoteCharacter
   quoteRegex = new RegExp(quoteCharacter, 'g')
   escapedQuoteRegex = new RegExp("\\\\#{quoteCharacter}", 'g')
@@ -41,10 +41,10 @@ toggleQuoteAtPosition = (editor, position) ->
 
   editor.setTextInBufferRange(range, newText)
 
-getNextQuote = (c, cs) ->
-  i = cs.indexOf(c)
+getNextQuoteCharacter = (quoteCharacter, quoteCharacters) ->
+  i = quoteCharacters.indexOf(quoteCharacter)
   return null if i == -1
-  cs[(i + 1) % cs.length]
+  quoteCharacters[(i + 1) % quoteCharacters.length]
 
 module.exports =
   config:

--- a/spec/toggle-quotes-spec.coffee
+++ b/spec/toggle-quotes-spec.coffee
@@ -1,6 +1,9 @@
 {toggleQuotes} = require '../lib/toggle-quotes'
 
 describe "ToggleQuotes", ->
+  beforeEach ->
+    atom.config.set('toggle-quotes.quoteCharacters', '\'"')
+
   describe "toggleQuotes(editor) js", ->
     editor = null
 
@@ -37,11 +40,20 @@ describe "ToggleQuotes", ->
         expect(editor.getCursorBufferPosition()).toEqual [4, 13]
 
     describe "when the cursor is inside a double quoted string", ->
-      it "switches the quotes to single", ->
-        editor.setCursorBufferPosition([0, 16])
-        toggleQuotes(editor)
-        expect(editor.lineTextForBufferRow(0)).toBe "console.log('Hello World');"
-        expect(editor.getCursorBufferPosition()).toEqual [0, 16]
+      describe "when using default config", ->
+        it "switches the double quotes to single quotes", ->
+          editor.setCursorBufferPosition([0, 16])
+          toggleQuotes(editor)
+          expect(editor.lineTextForBufferRow(0)).toBe "console.log('Hello World');"
+          expect(editor.getCursorBufferPosition()).toEqual [0, 16]
+
+      describe "when using custom config of backticks", ->
+        it "switches the double quotes to backticks", ->
+          atom.config.set('toggle-quotes.quoteCharacters', '\'"`')
+          editor.setCursorBufferPosition([0, 16])
+          toggleQuotes(editor)
+          expect(editor.lineTextForBufferRow(0)).toBe "console.log(`Hello World`);"
+          expect(editor.getCursorBufferPosition()).toEqual [0, 16]
 
     describe "when the cursor is inside a single quoted string", ->
       it "switches the quotes to double", ->


### PR DESCRIPTION
Moves the quote characters to config. Motivated by #14, but does not change the
default to include backticks.

Test Plan:

Ran specs. Let me know if you think we need more specs. I only added one.