### PR TITLE
Add more Mac-like keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Toggle quotes package [![Build Status](https://travis-ci.org/atom/toggle-quotes.svg?branch=master)](https://travis-ci.org/atom/toggle-quotes)
 
-`ctrl-"` to toggle a single-quoted string to a double-quoted string, and vice
+`ctrl-"` (or `cmd-"` on OS X) to toggle a single-quoted string to a double-quoted string, and vice
 versa. Available when using any grammar that supports single-quoted and
 double-quoted strings (e.g., JavaScript, Python, Ruby, etc.).
 

--- a/keymaps/toggle-quotes.cson
+++ b/keymaps/toggle-quotes.cson
@@ -1,2 +1,5 @@
-'atom-workspace':
+'.platform-linux atom-workspace, .platform-win32 atom-workspace':
   'ctrl-"': 'toggle-quotes:toggle'
+
+'.platform-darwin atom-workspace':
+  'cmd-"': 'toggle-quotes:toggle'


### PR DESCRIPTION
This adds <kbd>Cmd-"</kbd> for Macs, which is a more natural keybinding than <kbd>Ctrl-"</kbd>.

/cc @atom/non-github-maintainers 