### PR TITLE
Change keymap on linux and win32 plataforms

### DIFF
--- a/keymaps/toggle-quotes.cson
+++ b/keymaps/toggle-quotes.cson
@@ -1,5 +1,5 @@
 '.platform-linux atom-workspace, .platform-win32 atom-workspace':
-  'ctrl-"': 'toggle-quotes:toggle'
+  'ctrl-shift-2': 'toggle-quotes:toggle'
 
 '.platform-darwin atom-workspace':
   'cmd-"': 'toggle-quotes:toggle'


### PR DESCRIPTION
Hi,
This is one of the most useful package that I know in Atom. I often use it in PHP. But I found an issue on Linux keymaping. I can't use its shortcut  with my Ubuntu, it simply doesn't work, so I changed it to ctrl-shift-2, and I has never had problems again.
Thank!