### PR TITLE
displayBuffer has been deprecated

### DIFF
--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -21,14 +21,14 @@ const getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) => {
 
 const toggleQuoteAtPosition = (editor, position) => {
   let quoteChars = atom.config.get('toggle-quotes.quoteCharacters')
-  let range = editor.displayBuffer.bufferRangeForScopeAtPosition('.string.quoted', position)
+  let range = editor.bufferRangeForScopeAtPosition('.string.quoted', position)
 
   if (range == null) {
     // Attempt to match the current invalid region if it is wrapped in quotes
     // This is useful for languages where changing the quotes makes the range
     // invalid and so toggling again should properly restore the valid quotes
 
-    range = editor.displayBuffer.bufferRangeForScopeAtPosition('.invalid.illegal', position)
+    range = editor.bufferRangeForScopeAtPosition('.invalid.illegal', position)
     if (range) {
       let inner = quoteChars.split('').map(character => `${character}.*${character}`).join('|')
 


### PR DESCRIPTION
`TextEditor` now implements `bufferRangeForScopeAtPosition`.

Fixes #42 