### PR TITLE
Allow quote toggling in unrecognized (non-string as reported by the grammar) buffer areas

### DIFF
--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -21,14 +21,23 @@ const getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) => {
 
 const toggleQuoteAtPosition = (editor, position) => {
   let quoteChars = atom.config.get('toggle-quotes.quoteCharacters')
-  let range = editor.displayBuffer.bufferRangeForScopeAtPosition('.string.quoted', position)
+  let range = editor.bufferRangeForScopeAtPosition('.string.quoted', position)
 
   if (range == null) {
     // Attempt to match the current invalid region if it is wrapped in quotes
     // This is useful for languages where changing the quotes makes the range
     // invalid and so toggling again should properly restore the valid quotes
 
-    range = editor.displayBuffer.bufferRangeForScopeAtPosition('.invalid.illegal', position)
+    range = editor.bufferRangeForScopeAtPosition('.invalid.illegal', position)
+
+    if (range == null) {
+      // try current scope
+      let cursor = editor.getLastCursor();
+      let scopes = cursor.getScopeDescriptor().getScopesArray();
+      let currentScope = scopes[scopes.length - 1];
+      range = editor.bufferRangeForScopeAtPosition(currentScope, position);
+    }
+
     if (range) {
       let inner = quoteChars.split('').map(character => `${character}.*${character}`).join('|')
 

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -188,6 +188,71 @@ describe('ToggleQuotes', () => {
     })
   })
 
+  describe('toggleQuotes(editor) with custom quote characters', () => {
+    let editor = null
+    let quoteCharacters = ["'", '"', "`"];
+
+    beforeEach(() => {
+      atom.config.set('toggle-quotes.quoteCharacters', quoteCharacters.join(''))
+    })
+
+    describe('in a recognized and working file grammar', () => {
+      beforeEach(() => {
+        waitsForPromise(() => {
+          return atom.packages.activatePackage('language-javascript')
+        })
+
+        waitsForPromise(() => {
+          return atom.packages.activatePackage('language-ruby')
+        })
+
+        waitsForPromise(() => {
+          return atom.workspace.open()
+        })
+
+        runs(() => {
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setGrammar(atom.grammars.selectGrammar('test.js'))
+        })
+      })
+
+      it('toggles between the quotes', () => {
+        editor.setText('`a custom quoted string`')
+        editor.setCursorBufferPosition([0, 4])
+        let expectedQuote;
+
+        quoteCharacters.forEach(expectedQuote => {
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe(`${expectedQuote}a custom quoted string${expectedQuote}`)
+        });
+      })
+    })
+
+    describe('in an unrecognized file', () => {
+      beforeEach(() => {
+        waitsForPromise(() => {
+          return atom.workspace.open()
+        })
+
+        runs(() => {
+          editor = atom.workspace.getActiveTextEditor()
+          editor.setGrammar(atom.grammars.selectGrammar('test.foo'))
+        })
+      })
+
+      it('toggles between the quotes', () => {
+        editor.setText('`a custom quoted string`')
+        editor.setCursorBufferPosition([0, 4])
+        let expectedQuote;
+
+        quoteCharacters.forEach(expectedQuote => {
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe(`${expectedQuote}a custom quoted string${expectedQuote}`)
+        });
+      })
+    })
+  })
+
   it('activates when a command is triggered', () => {
     let activatePromise = atom.packages.activatePackage('toggle-quotes')
 


### PR DESCRIPTION
## Description Of The Change
This fix provides a fallback if the current grammar doesn't report the current buffer as `.string.quoted`. This happens in cases where the quote characters have been customized, most commonly when the user has added a es6-style backtick as a quote character.

When toggling quotes in a grammar that reports these regions correctly, you can toggle from 
```
"hello" -> 'hello' -> `hello`
```
but after that when it should cycle back to the first quote character, it stops working because the current buffer area is no longer recognized as `.string.quoted`. A fallback was already in place to check for a `.invalid.illegal` region, but that doesn't always work. Now, if no region has been found, it looks in the current scope.

## Alternate Designs
I kept the check for the `editor.bufferRangeForScopeAtPosition('.invalid.illegal', position)` before my added code, but I'm not positive that's necessary anymore. It doesn't seem to be hurting anything.

## Why Should This Be In Core?
Because it looks like this package hasn't received any love in a long time, and judging by the outstanding issues and PRs this might resolve some problems.

## Benefits
Better quote toggling for the masses. Toggling in more file types. 

## Possible Drawbacks
Sometimes people hate change, even if it's good.

## Applicable Issues
This resolves a number of reported issues: #35, #31, and #43, and #9