### PR TITLE
:bug: Fix package activation under Atom v1.16.0

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,7 @@ import {toggleQuotes} from './toggle-quotes'
 export default {
   config: configSchema,
 
-  activate: () => {
+  activate () {
     this.subscription = atom.commands.add('atom-text-editor', 'toggle-quotes:toggle', () => {
       let editor = atom.workspace.getActiveTextEditor()
       if (editor) {
@@ -15,7 +15,7 @@ export default {
     })
   },
 
-  deactivate: () => {
+  deactivate () {
     this.subscription.dispose()
   }
 }


### PR DESCRIPTION
Atom v1.16.0-beta0 doesn't allow activation functions to be declared in this manner.

**NOTE**: This may just be a bug in the [new transpilation](https://github.com/atom/atom/pull/13823) introduced with Atom v1.16.0-beta0!

Fixes #47.