### PR TITLE
Determine the string scope selector dynamically

### DIFF
--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -21,7 +21,14 @@ const getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) => {
 
 const toggleQuoteAtPosition = (editor, position) => {
   let quoteChars = atom.config.get('toggle-quotes.quoteCharacters')
-  let range = editor.bufferRangeForScopeAtPosition('.string.quoted', position)
+
+  let stringScopeSelector = editor.scopeDescriptorForBufferPosition(position).scopes.filter((scope) => {
+    return scope.match(/^string\./);
+  });
+
+  let scopeSelector = stringScopeSelector[0];
+
+  let range = editor.bufferRangeForScopeAtPosition(scopeSelector, position)
 
   if (range == null) {
     // Attempt to match the current invalid region if it is wrapped in quotes

--- a/spec/toggle-quotes-typescript-spec.js
+++ b/spec/toggle-quotes-typescript-spec.js
@@ -5,7 +5,7 @@ import {raw as r} from '../lib/string-helper'
 
 describe('ToggleQuotes', () => {
   beforeEach(() => {
-    atom.config.set('toggle-quotes.quoteCharacters', '\'"')
+    atom.config.set('toggle-quotes.quoteCharacters', '\'"`')
   })
 
   describe('toggleQuotes(editor) typescript', () => {

--- a/spec/toggle-quotes-typescript-spec.js
+++ b/spec/toggle-quotes-typescript-spec.js
@@ -1,0 +1,44 @@
+'use babel'
+
+import {toggleQuotes} from '../lib/toggle-quotes'
+import {raw as r} from '../lib/string-helper'
+
+describe('ToggleQuotes', () => {
+  beforeEach(() => {
+    atom.config.set('toggle-quotes.quoteCharacters', '\'"')
+  })
+
+  describe('toggleQuotes(editor) typescript', () => {
+    let editor = null
+
+    beforeEach(() => {
+      waitsForPromise(() => {
+        return atom.packages.activatePackage('atom-typescript')
+      })
+
+      waitsForPromise(() => {
+        return atom.workspace.open()
+      })
+
+      runs(() => {
+        editor = atom.workspace.getActiveTextEditor()
+        editor.setText(
+          r`let foo = "foo"
+          let bar = 'bar'
+          let baz = \`baz\``
+        )
+        editor.setGrammar(atom.grammars.selectGrammar('test.ts'))
+      })
+    })
+
+    describe('when cursor is inside a double quoted string', () => {
+      it('switches quotes to backtick character', () => {
+        editor.setCursorBufferPosition([0, 16])
+        toggleQuotes(editor)
+        expect(editor.lineTextForBufferRow(0)).toBe("let foo = `foo`")
+        expect(editor.getCursorBufferPosition()).toEqual([0, 16])
+      })
+    })
+  })
+
+})


### PR DESCRIPTION
### Description of the Change

In typescript, running 'toggle-quotes:toggle' in a template string does not cycle the quotes even after setting 'toggle-quotes.quoteCharacters' to '\'"`'

This happends because we try to get the editor range based on the scope selector ".string.quoted" which is not correct in .ts files for template strings.

This PR determines the correct scope dynamically by finding the current scope matching /^string\./ and uses this scope to get the editor's range.

### Alternate Designs

NA

### Why Should This Be In Core?

Since we can configure toggle-quotes.quoteCharacters by adding the backtick, the package should be able to cycle from the backtick.

### Benefits

See above

### Possible Drawbacks

Might break for some languages that do not use /^string\./ for string scopes ...

### Applicable Issues

#35 #51
