### PR TITLE
Allow for language-specific quote character settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Configuration Key Path      | Type | Default | Description
 ----------------------------|------|---------|------------
 `toggle-quotes.quoteCharacters` | `string` | `'"` | The characters `toggle-quotes:toggle` toggles between. No whitespace.
 
+You can add [language-specific settings](http://flight-manual.atom.io/using-atom/sections/basic-customization/#language-specific-configuration-settings) for languages with more exotic string delimiters. For example, this setting in your `config.cson` will add backticks in JavaScript files, but not in other kinds of files:
+
+```cson
+".js.source":
+  "toggle-quotes":
+    quoteCharacters: "\"'`"
+```
+
 ## Contributing
 
 Always feel free to help out!  Whether it's filing bugs and feature requests

--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -20,7 +20,9 @@ const getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) => {
 }
 
 const toggleQuoteAtPosition = (editor, position) => {
-  let quoteChars = atom.config.get('toggle-quotes.quoteCharacters')
+  let quoteChars = atom.config.get('toggle-quotes.quoteCharacters', {
+    scope: editor.getRootScopeDescriptor()
+  })
   let range = editor.bufferRangeForScopeAtPosition('.string.quoted', position)
 
   if (range == null) {

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -73,6 +73,17 @@ describe('ToggleQuotes', () => {
       })
     })
 
+    describe('when using a scope-specific config override', () => {
+      it('prefers the scope-specific setting', () => {
+        atom.config.set('toggle-quotes.quoteCharacters', '\'"~', { scopeSelector: '.source.js' })
+        editor.setCursorBufferPosition([0, 16])
+        toggleQuotes(editor)
+        expect(editor.lineTextForBufferRow(0)).toBe("console.log(~Hello World~)")
+        expect(editor.getCursorBufferPosition()).toEqual([0, 16])
+        atom.config.unset('toggle-quotes.quoteCharacters', { scope: '.source.js' })
+      })
+    })
+
     describe('when the cursor is inside a single quoted string', () => {
       it('switches the quotes to double', () => {
         editor.setCursorBufferPosition([1, 16])

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -78,7 +78,7 @@ describe('ToggleQuotes', () => {
         atom.config.set('toggle-quotes.quoteCharacters', '\'"~', { scopeSelector: '.source.js' })
         editor.setCursorBufferPosition([0, 16])
         toggleQuotes(editor)
-        expect(editor.lineTextForBufferRow(0)).toBe("console.log(~Hello World~)")
+        expect(editor.lineTextForBufferRow(0)).toBe('console.log(~Hello World~)')
         expect(editor.getCursorBufferPosition()).toEqual([0, 16])
         atom.config.unset('toggle-quotes.quoteCharacters', { scope: '.source.js' })
       })

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -13,15 +13,12 @@ describe('ToggleQuotes', () => {
 
     beforeEach(() => {
       waitsForPromise(() => {
-        return atom.packages.activatePackage('language-javascript')
-      })
-
-      waitsForPromise(() => {
-        return atom.packages.activatePackage('language-json')
-      })
-
-      waitsForPromise(() => {
-        return atom.workspace.open()
+        return Promise.all([
+          atom.packages.activatePackage('language-javascript'),
+          atom.packages.activatePackage('language-json'),
+          atom.packages.activatePackage('language-python'),
+          atom.workspace.open()
+        ])
       })
 
       runs(() => {
@@ -82,6 +79,17 @@ describe('ToggleQuotes', () => {
         expect(editor.getCursorBufferPosition()).toEqual([0, 16])
         atom.config.unset('toggle-quotes.quoteCharacters', { scope: '.source.js' })
       })
+
+      it('does not bleed into the wrong scope', () => {
+        atom.config.set('toggle-quotes.quoteCharacters', '\'"~', { scopeSelector: '.source.js' })
+        editor.setGrammar(atom.grammars.selectGrammar('test.py'))
+        editor.setCursorBufferPosition([0, 16])
+        toggleQuotes(editor)
+        expect(editor.lineTextForBufferRow(0)).toBe('console.log(\'Hello World\')')
+        expect(editor.getCursorBufferPosition()).toEqual([0, 16])
+        atom.config.unset('toggle-quotes.quoteCharacters', { scope: '.source.js' })
+      })
+
     })
 
     describe('when the cursor is inside a single quoted string', () => {

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -89,7 +89,6 @@ describe('ToggleQuotes', () => {
         expect(editor.getCursorBufferPosition()).toEqual([0, 16])
         atom.config.unset('toggle-quotes.quoteCharacters', { scope: '.source.js' })
       })
-
     })
 
     describe('when the cursor is inside a single quoted string', () => {


### PR DESCRIPTION
### Description of the Change

Currently, the `quoteCharacters` setting is read globally and only globally. You can try to specify a scope-specific setting in your `keymap.cson`…

```cson
".js.source":
  "toggle-quotes":
    quoteCharacters: "\"'`"
```

…but it'll be ignored.

This discourages the user from adding (say) backticks to the setting — it'll work in languages like JavaScript that recognize the backtick as a string delimiter, but it'll cause the command to break in other languages where the grammar stops recognizing the string as a string once we cycle into backticks.

The solution is to include a scope descriptor when calling `Config#get`, thus ensuring we get a custom setting for a particular language if it exists, and falling back to the global setting if it doesn't.

Added a test to the specs.

### Alternate Designs

N/A

### Benefits

This makes the package much more useful (to me, at least).

### Possible Drawbacks

I can't think of any. It's not the most discoverable feature, so it might warrant a mention in the docs, but it's certainly an improvement over the status quo.

### Applicable Issues

Didn't find any.
