### PR TITLE
Use tree sitter query APIs to find nodes to operate on

### DIFF
--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -19,13 +19,22 @@ const getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) => {
   }
 }
 
+const quoted = ({text}) =>
+  (text.startsWith('"') || text.startsWith("'")) && text.endsWith(text[0])
+
 const toggleQuoteAtPosition = (editor, position) => {
   let quoteChars = atom.config.get('toggle-quotes.quoteCharacters', {
     scope: editor.getRootScopeDescriptor()
   })
-  let range = editor.bufferRangeForScopeAtPosition('.string', position)
+  let range
+  if (editor.languageMode.getSyntaxNodeAtPosition) {
+    const node = editor.languageMode.getSyntaxNodeAtPosition(position, quoted)
+    range = node && node.range
+  } else {
+    editor.bufferRangeForScopeAtPosition('.string.quoted', position)
+  }
 
-  if (range == null) {
+  if (!range) {
     // Attempt to match the current invalid region if it is wrapped in quotes
     // This is useful for languages where changing the quotes makes the range
     // invalid and so toggling again should properly restore the valid quotes

--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -23,7 +23,7 @@ const toggleQuoteAtPosition = (editor, position) => {
   let quoteChars = atom.config.get('toggle-quotes.quoteCharacters', {
     scope: editor.getRootScopeDescriptor()
   })
-  let range = editor.bufferRangeForScopeAtPosition('.string.quoted', position)
+  let range = editor.bufferRangeForScopeAtPosition('.string', position)
 
   if (range == null) {
     // Attempt to match the current invalid region if it is wrapped in quotes

--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -31,7 +31,7 @@ const toggleQuoteAtPosition = (editor, position) => {
     const node = editor.languageMode.getSyntaxNodeAtPosition(position, quoted)
     range = node && node.range
   } else {
-    editor.bufferRangeForScopeAtPosition('.string.quoted', position)
+    range = editor.bufferRangeForScopeAtPosition('.string.quoted', position)
   }
 
   if (!range) {


### PR DESCRIPTION
Use the new `TreeSitterLanguageMode::getSyntaxNodeAtPosition` API to find nodes to operate on.