### PR TITLE
Don't select terminals.

### DIFF
--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -20,7 +20,9 @@ const getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) => {
 }
 
 const quoted = ({text}) =>
-  (text.startsWith('"') || text.startsWith("'")) && text.endsWith(text[0])
+  (text.startsWith('"') || text.startsWith("'")) &&
+  text.endsWith(text[0]) &&
+  text.length > 1
 
 const toggleQuoteAtPosition = (editor, position) => {
   let quoteChars = atom.config.get('toggle-quotes.quoteCharacters', {

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -66,7 +66,7 @@ describe('ToggleQuotes', () => {
         it('switches the double quotes to single quotes', () => {
           editor.setCursorBufferPosition([5, 13])
           toggleQuotes(editor)
-          expect(editor.lineTextForBufferRow(5)).toBe('console.log("boom")')
+          expect(editor.lineTextForBufferRow(5)).toBe(`console.log('boom')`)
           expect(editor.getCursorBufferPosition()).toEqual([5, 13])
         })
       })

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -28,7 +28,8 @@ describe('ToggleQuotes', () => {
           console.log('Hello World')
           console.log("Hello 'World'")
           console.log('Hello "World"')
-          console.log('')`
+          console.log('')
+          console.log("boom")`
         )
         editor.setGrammar(atom.grammars.selectGrammar('test.js'))
       })
@@ -56,6 +57,17 @@ describe('ToggleQuotes', () => {
           toggleQuotes(editor)
           expect(editor.lineTextForBufferRow(0)).toBe("console.log('Hello World')")
           expect(editor.getCursorBufferPosition()).toEqual([0, 16])
+        })
+      })
+    })
+
+    describe('when the cursor is barely inside a double quoted string', () => {
+      describe('when using default config', () => {
+        it('switches the double quotes to single quotes', () => {
+          editor.setCursorBufferPosition([5, 13])
+          toggleQuotes(editor)
+          expect(editor.lineTextForBufferRow(5)).toBe('console.log("boom")')
+          expect(editor.getCursorBufferPosition()).toEqual([5, 13])
         })
       })
     })


### PR DESCRIPTION
Add a check that the node has a `length > 1` to avoid selecting terminal nodes.

Fixes #61 