### PR TITLE
Ensure toggling works in tree-sitter grammars with unorthodox strings.

### DIFF
--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -19,10 +19,18 @@ const getNextQuoteCharacter = (quoteCharacter, allQuoteCharacters) => {
   }
 }
 
-const quoted = ({text}) =>
-  (text.startsWith('"') || text.startsWith("'")) &&
-  text.endsWith(text[0]) &&
-  text.length > 1
+const escapePattern = (s) => {
+  return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+}
+
+// Using the quote characters configured by the user, build a pattern that can
+// be used to filter the syntax nodes in tree-sitter mode.
+const makePredicate = (quoteChars) => {
+  // We want text that begins and ends with the same quote character (and
+  // _might_ start with one of Python's string format prefixes).
+  let pattern = new RegExp(`^[uUr]?([${escapePattern(quoteChars)}])[\\s\\S]*(\\1)$`, 'g')
+  return ({ text }) => pattern.test(text)
+}
 
 const toggleQuoteAtPosition = (editor, position) => {
   let quoteChars = atom.config.get('toggle-quotes.quoteCharacters', {
@@ -30,7 +38,7 @@ const toggleQuoteAtPosition = (editor, position) => {
   })
   let range
   if (editor.languageMode.getSyntaxNodeAtPosition) {
-    const node = editor.languageMode.getSyntaxNodeAtPosition(position, quoted)
+    const node = editor.languageMode.getSyntaxNodeAtPosition(position, makePredicate(quoteChars))
     range = node && node.range
   } else {
     range = editor.bufferRangeForScopeAtPosition('.string.quoted', position)

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -29,7 +29,8 @@ describe('ToggleQuotes', () => {
           console.log("Hello 'World'")
           console.log('Hello "World"')
           console.log('')
-          console.log("boom")`
+          console.log("boom")
+          console.log(\`backticks\`)`
         )
         editor.setGrammar(atom.grammars.selectGrammar('test.js'))
       })
@@ -79,6 +80,14 @@ describe('ToggleQuotes', () => {
         toggleQuotes(editor)
         expect(editor.lineTextForBufferRow(0)).toBe('console.log(`Hello World`)')
         expect(editor.getCursorBufferPosition()).toEqual([0, 16])
+      })
+
+      it('switches backticks to single quotes', () => {
+        atom.config.set('toggle-quotes.quoteCharacters', '\'"`')
+        editor.setCursorBufferPosition([6, 18])
+        toggleQuotes(editor)
+        expect(editor.lineTextForBufferRow(6)).toBe('console.log(\'backticks\')')
+        expect(editor.getCursorBufferPosition()).toEqual([6, 18])
       })
     })
 


### PR DESCRIPTION
### Description of the Change

#### Problem

I [remarked here](https://github.com/atom/toggle-quotes/pull/58#discussion_r229873180) about a change that seemed like it introduced a regression: in order for the package to determine if it was inside a toggle-able string when the current file is using a tree-sitter grammar, it queries for syntax nodes with a function predicate that is too brittle. Any string that doesn’t begin and end with a single quote or double quote is guaranteed to get ignored.

But sometimes it shouldn’t be ignored. Two examples:

* ES6 has backtick-delimited strings, yet a custom scope setting for JavaScript that adds <code>\`</code> as a quote character won’t be respected if the tree-sitter parser is enabled.
* Python has strings like `u"this one"`. The `u` is a string prefix for a unicode string. The toggle-quotes package can account for this, but currently (in tree-sitter mode) these kinds of strings get thrown out before that special-case code can act. (In fact, there are specs for this behavior, and they appear to be failing on master right now.)

#### Solution

The predicate needs to take the (possibly scope-specific) quote character setting into account. So we need to build a predicate at command invocation time using the configured quote characters.

Hence we build a regex on the fly that we use to test whether the syntax node’s text begins and ends with the same quote character. The pattern also optionally allows for one of Python’s string prefixes.

The breaking specs are no longer breaking. I also added a test for the backtick scenario in JavaScript.

### Alternate Designs

I can’t think of any. I don’t know enough about tree-sitter grammars to go too deep on this. Happy to hear other solutions.

### Benefits

This package will work identically whether tree-sitter grammars are enabled or disabled.

### Possible Drawbacks

Performance, perhaps? We build the regex only once per invocation of the `toggle-quotes:toggle` command, but perhaps it’s more costly to call `RegExp#test` inside of the predicate than to call `String#startsWith` and `String#endsWith`. Can’t imagine the difference is meaningful, though.

### Applicable Issues

The regression was introduced in #58. Was going to open an issue for it, but ended up writing this PR instead.