### PR TITLE
Better escaped character support

### DIFF
--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -80,14 +80,14 @@ const toggleQuoteAtPosition = (editor, position) => {
     return
   }
 
-  let locateEscapesAndQuotesRegex = new RegExp(`\\\\.|${nextQuoteCharacter}`, 'g')
+  let locateEscapesAndQuotesRegex = new RegExp(`\\\\.|${escapePattern(nextQuoteCharacter)}`, 'g')
 
   let newText = text
     .replace(locateEscapesAndQuotesRegex, m => {
-      if (m[0] === '\\') {
-        return m[1] === quoteCharacter ? quoteCharacter : m
-      } else {
+      if (m[0] === nextQuoteCharacter) {
         return '\\' + nextQuoteCharacter
+      } else {
+        return m[1] === quoteCharacter ? quoteCharacter : m
       }
     })
 

--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -80,7 +80,7 @@ const toggleQuoteAtPosition = (editor, position) => {
     return
   }
 
-  let locateEscapesAndQuotesRegex = new RegExp(`\\\\.|${escapePattern(nextQuoteCharacter)}`, 'g')
+  const locateEscapesAndQuotesRegex = new RegExp(`\\\\.|${escapePattern(nextQuoteCharacter)}`, 'g')
 
   let newText = text
     .replace(locateEscapesAndQuotesRegex, m => {

--- a/lib/toggle-quotes.js
+++ b/lib/toggle-quotes.js
@@ -80,13 +80,16 @@ const toggleQuoteAtPosition = (editor, position) => {
     return
   }
 
-  // let quoteRegex = new RegExp(quoteCharacter, 'g')
-  let escapedQuoteRegex = new RegExp(`\\\\${quoteCharacter}`, 'g')
-  let nextQuoteRegex = new RegExp(nextQuoteCharacter, 'g')
+  let locateEscapesAndQuotesRegex = new RegExp(`\\\\.|${nextQuoteCharacter}`, 'g')
 
   let newText = text
-    .replace(nextQuoteRegex, `\\${nextQuoteCharacter}`)
-    .replace(escapedQuoteRegex, quoteCharacter)
+    .replace(locateEscapesAndQuotesRegex, m => {
+      if (m[0] === '\\') {
+        return m[1] === quoteCharacter ? quoteCharacter : m
+      } else {
+        return '\\' + nextQuoteCharacter
+      }
+    })
 
   newText = prefix + nextQuoteCharacter + newText.slice(1 + prefix.length, -1) + nextQuoteCharacter
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "alter": {
@@ -51,7 +51,7 @@
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
       "dev": true,
       "requires": {
-        "stable": "~0.1.3"
+        "stable": "0.1.8"
       }
     },
     "amdefine": {
@@ -84,7 +84,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-union": {
@@ -93,7 +93,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -126,7 +126,7 @@
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-code-frame": {
@@ -135,9 +135,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "js-tokens": {
@@ -154,52 +154,52 @@
       "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
       "dev": true,
       "requires": {
-        "babel-plugin-constant-folding": "^1.0.1",
-        "babel-plugin-dead-code-elimination": "^1.0.2",
-        "babel-plugin-eval": "^1.0.1",
-        "babel-plugin-inline-environment-variables": "^1.0.1",
-        "babel-plugin-jscript": "^1.0.4",
-        "babel-plugin-member-expression-literals": "^1.0.1",
-        "babel-plugin-property-literals": "^1.0.1",
-        "babel-plugin-proto-to-assign": "^1.0.3",
-        "babel-plugin-react-constant-elements": "^1.0.3",
-        "babel-plugin-react-display-name": "^1.0.3",
-        "babel-plugin-remove-console": "^1.0.1",
-        "babel-plugin-remove-debugger": "^1.0.1",
-        "babel-plugin-runtime": "^1.0.7",
-        "babel-plugin-undeclared-variables-check": "^1.0.2",
-        "babel-plugin-undefined-to-void": "^1.1.6",
-        "babylon": "^5.8.38",
-        "bluebird": "^2.9.33",
-        "chalk": "^1.0.0",
-        "convert-source-map": "^1.1.0",
-        "core-js": "^1.0.0",
-        "debug": "^2.1.1",
-        "detect-indent": "^3.0.0",
-        "esutils": "^2.0.0",
-        "fs-readdir-recursive": "^0.1.0",
-        "globals": "^6.4.0",
-        "home-or-tmp": "^1.0.0",
-        "is-integer": "^1.0.4",
+        "babel-plugin-constant-folding": "1.0.1",
+        "babel-plugin-dead-code-elimination": "1.0.2",
+        "babel-plugin-eval": "1.0.1",
+        "babel-plugin-inline-environment-variables": "1.0.1",
+        "babel-plugin-jscript": "1.0.4",
+        "babel-plugin-member-expression-literals": "1.0.1",
+        "babel-plugin-property-literals": "1.0.1",
+        "babel-plugin-proto-to-assign": "1.0.4",
+        "babel-plugin-react-constant-elements": "1.0.3",
+        "babel-plugin-react-display-name": "1.0.3",
+        "babel-plugin-remove-console": "1.0.1",
+        "babel-plugin-remove-debugger": "1.0.1",
+        "babel-plugin-runtime": "1.0.7",
+        "babel-plugin-undeclared-variables-check": "1.0.2",
+        "babel-plugin-undefined-to-void": "1.1.6",
+        "babylon": "5.8.38",
+        "bluebird": "2.11.0",
+        "chalk": "1.1.3",
+        "convert-source-map": "1.6.0",
+        "core-js": "1.2.7",
+        "debug": "2.6.9",
+        "detect-indent": "3.0.1",
+        "esutils": "2.0.2",
+        "fs-readdir-recursive": "0.1.2",
+        "globals": "6.4.1",
+        "home-or-tmp": "1.0.0",
+        "is-integer": "1.0.7",
         "js-tokens": "1.0.1",
-        "json5": "^0.4.0",
-        "lodash": "^3.10.0",
-        "minimatch": "^2.0.3",
-        "output-file-sync": "^1.1.0",
-        "path-exists": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "private": "^0.1.6",
+        "json5": "0.4.0",
+        "lodash": "3.10.1",
+        "minimatch": "2.0.10",
+        "output-file-sync": "1.1.2",
+        "path-exists": "1.0.0",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
         "regenerator": "0.8.40",
-        "regexpu": "^1.3.0",
-        "repeating": "^1.1.2",
-        "resolve": "^1.1.6",
-        "shebang-regex": "^1.0.0",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.0",
-        "source-map-support": "^0.2.10",
-        "to-fast-properties": "^1.0.0",
-        "trim-right": "^1.0.0",
-        "try-resolve": "^1.0.0"
+        "regexpu": "1.3.0",
+        "repeating": "1.1.3",
+        "resolve": "1.8.1",
+        "shebang-regex": "1.0.0",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "source-map-support": "0.2.10",
+        "to-fast-properties": "1.0.3",
+        "trim-right": "1.0.1",
+        "try-resolve": "1.0.1"
       },
       "dependencies": {
         "globals": {
@@ -220,7 +220,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.11"
           }
         },
         "source-map": {
@@ -237,7 +237,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-constant-folding": {
@@ -288,7 +288,7 @@
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
       "dev": true,
       "requires": {
-        "lodash": "^3.9.3"
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -335,7 +335,7 @@
       "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
       "dev": true,
       "requires": {
-        "leven": "^1.0.2"
+        "leven": "1.0.2"
       }
     },
     "babel-plugin-undefined-to-void": {
@@ -350,8 +350,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
@@ -368,15 +368,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "babylon": {
@@ -399,10 +399,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -429,7 +429,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -457,8 +457,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -467,11 +467,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "circular-json": {
@@ -486,7 +486,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-width": {
@@ -501,8 +501,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -538,15 +538,15 @@
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
       "requires": {
-        "commander": "^2.5.0",
-        "detective": "^4.3.1",
-        "glob": "^5.0.15",
-        "graceful-fs": "^4.1.2",
-        "iconv-lite": "^0.4.5",
-        "mkdirp": "^0.5.0",
-        "private": "^0.1.6",
-        "q": "^1.1.2",
-        "recast": "^0.11.17"
+        "commander": "2.17.1",
+        "detective": "4.7.1",
+        "glob": "5.0.15",
+        "graceful-fs": "4.1.15",
+        "iconv-lite": "0.4.24",
+        "mkdirp": "0.5.1",
+        "private": "0.1.8",
+        "q": "1.5.1",
+        "recast": "0.11.23"
       },
       "dependencies": {
         "esprima": {
@@ -561,11 +561,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "recast": {
@@ -575,9 +575,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.9.6",
-            "esprima": "~3.1.0",
-            "private": "~0.1.5",
-            "source-map": "~0.5.0"
+            "esprima": "3.1.3",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
           }
         },
         "source-map": {
@@ -600,10 +600,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "config-chain": {
@@ -612,8 +612,8 @@
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
       }
     },
     "convert-source-map": {
@@ -622,7 +622,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "core-js": {
@@ -643,7 +643,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.46"
       }
     },
     "debug": {
@@ -679,7 +679,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.4"
       }
     },
     "defined": {
@@ -694,16 +694,16 @@
       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
       "dev": true,
       "requires": {
-        "alter": "~0.2.0",
-        "ast-traverse": "~0.1.1",
-        "breakable": "~1.0.0",
-        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "~0.1.0",
-        "simple-is": "~0.2.0",
-        "stringmap": "~0.2.2",
-        "stringset": "~0.2.1",
-        "tryor": "~0.1.2",
-        "yargs": "~3.27.0"
+        "alter": "0.2.0",
+        "ast-traverse": "0.1.1",
+        "breakable": "1.0.0",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "0.1.0",
+        "simple-is": "0.2.0",
+        "stringmap": "0.2.2",
+        "stringset": "0.2.1",
+        "tryor": "0.1.2",
+        "yargs": "3.27.0"
       },
       "dependencies": {
         "esprima-fb": {
@@ -720,13 +720,13 @@
       "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
       "dev": true,
       "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^3.0.9",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1",
-        "xtend": "^4.0.0"
+        "find-root": "1.1.0",
+        "glob": "7.1.3",
+        "ignore": "3.3.10",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.9",
+        "uniq": "1.0.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "find-root": {
@@ -743,12 +743,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       }
     },
     "detect-indent": {
@@ -757,9 +757,9 @@
       "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "minimist": "^1.1.0",
-        "repeating": "^1.1.0"
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0",
+        "repeating": "1.1.3"
       }
     },
     "detective": {
@@ -768,8 +768,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
+        "acorn": "5.7.3",
+        "defined": "1.0.0"
       }
     },
     "dezalgo": {
@@ -778,8 +778,8 @@
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
+        "asap": "2.0.6",
+        "wrappy": "1.0.2"
       }
     },
     "diff": {
@@ -794,8 +794,8 @@
       "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.0.1",
-        "diff": "^1.3.2"
+        "ansi-styles": "2.2.1",
+        "diff": "1.4.0"
       }
     },
     "doctrine": {
@@ -804,7 +804,7 @@
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
-        "esutils": "^1.1.6",
+        "esutils": "1.1.6",
         "isarray": "0.0.1"
       },
       "dependencies": {
@@ -828,12 +828,12 @@
       "integrity": "sha512-GWjSI19PVJAM9IZRGOS+YKI8LN+/sjkSjNyvxL5ucqP9/IqtYNXBaQ/6c/hkPNYQHyOHra2KoXZI/JVpuqwmcQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^10.11.7",
-        "@types/semver": "^5.5.0",
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.3",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
+        "@types/node": "10.12.4",
+        "@types/semver": "5.5.0",
+        "commander": "2.19.0",
+        "lru-cache": "4.1.3",
+        "semver": "5.6.0",
+        "sigmund": "1.0.1"
       },
       "dependencies": {
         "commander": {
@@ -856,9 +856,9 @@
       "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -867,9 +867,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -878,12 +878,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-set": {
@@ -892,11 +892,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -905,8 +905,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46"
       }
     },
     "es6-weak-map": {
@@ -915,10 +915,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -933,10 +933,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "esformatter": {
@@ -945,24 +945,24 @@
       "integrity": "sha1-e6mIKqPtMIOfivds3fTxLaM3084=",
       "dev": true,
       "requires": {
-        "debug": "^0.7.4",
-        "disparity": "^2.0.0",
-        "espree": "^2.2.4",
-        "glob": "^5.0.3",
-        "minimist": "^1.1.1",
-        "mout": ">=0.9 <2.0",
-        "npm-run": "^2.0.0",
-        "resolve": "^1.1.5",
-        "rocambole": ">=0.7 <2.0",
-        "rocambole-indent": "^2.0.4",
-        "rocambole-linebreak": "^1.0.0",
-        "rocambole-node": "~1.0",
-        "rocambole-token": "^1.1.2",
-        "rocambole-whitespace": "^1.0.0",
-        "stdin": "*",
-        "strip-json-comments": "~0.1.1",
-        "supports-color": "^1.3.1",
-        "user-home": "^2.0.0"
+        "debug": "0.7.4",
+        "disparity": "2.0.0",
+        "espree": "2.2.5",
+        "glob": "5.0.15",
+        "minimist": "1.2.0",
+        "mout": "1.1.0",
+        "npm-run": "2.0.0",
+        "resolve": "1.8.1",
+        "rocambole": "0.7.0",
+        "rocambole-indent": "2.0.4",
+        "rocambole-linebreak": "1.0.2",
+        "rocambole-node": "1.0.0",
+        "rocambole-token": "1.2.1",
+        "rocambole-whitespace": "1.0.0",
+        "stdin": "0.0.1",
+        "strip-json-comments": "0.1.3",
+        "supports-color": "1.3.1",
+        "user-home": "2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -977,11 +977,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "strip-json-comments": {
@@ -1004,7 +1004,7 @@
       "integrity": "sha1-RaeP9GIrHUnkT1a0mQV2amMpDAc=",
       "dev": true,
       "requires": {
-        "string.prototype.endswith": "^0.2.0"
+        "string.prototype.endswith": "0.2.0"
       }
     },
     "esformatter-ignore": {
@@ -1019,11 +1019,11 @@
       "integrity": "sha1-QRxE7TJHVK+VquXe2FbVp+78td8=",
       "dev": true,
       "requires": {
-        "babel-core": "^5.8.34",
-        "esformatter-ignore": "^0.1.3",
-        "extend": "^2.0.1",
-        "fresh-falafel": "^1.2.0",
-        "js-beautify": "^1.5.10"
+        "babel-core": "5.8.38",
+        "esformatter-ignore": "0.1.3",
+        "extend": "2.0.2",
+        "fresh-falafel": "1.2.0",
+        "js-beautify": "1.8.8"
       }
     },
     "esformatter-literal-notation": {
@@ -1032,8 +1032,8 @@
       "integrity": "sha1-cQ57QgF1/j9+WvrVu60ykQOELi8=",
       "dev": true,
       "requires": {
-        "rocambole": "^0.3.6",
-        "rocambole-token": "^1.2.1"
+        "rocambole": "0.3.6",
+        "rocambole-token": "1.2.1"
       },
       "dependencies": {
         "esprima": {
@@ -1048,7 +1048,7 @@
           "integrity": "sha1-Teu/WUMUS8e2AG2Vvo+swLdDUqc=",
           "dev": true,
           "requires": {
-            "esprima": "~1.0"
+            "esprima": "1.0.4"
           }
         }
       }
@@ -1059,10 +1059,10 @@
       "integrity": "sha1-CFQHLQSHU57TnK442KVDLBfsEdM=",
       "dev": true,
       "requires": {
-        "acorn-to-esprima": "^2.0.8",
-        "babel-traverse": "^6.9.0",
-        "babylon": "^6.8.0",
-        "rocambole": "^0.7.0"
+        "acorn-to-esprima": "2.0.8",
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0",
+        "rocambole": "0.7.0"
       },
       "dependencies": {
         "babylon": {
@@ -1085,10 +1085,10 @@
       "integrity": "sha1-47US0dTgcxDqvKv1cnfqfIpW4kI=",
       "dev": true,
       "requires": {
-        "esformatter-parser": "^1.0",
-        "rocambole": ">=0.6.0 <2.0",
-        "rocambole-linebreak": "^1.0.2",
-        "rocambole-token": "^1.2.1"
+        "esformatter-parser": "1.0.0",
+        "rocambole": "0.7.0",
+        "rocambole-linebreak": "1.0.2",
+        "rocambole-token": "1.2.1"
       }
     },
     "esformatter-spaced-lined-comment": {
@@ -1103,41 +1103,41 @@
       "integrity": "sha1-p1qvB+KGUHcu0OcNqizggwebZRQ=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "concat-stream": "^1.4.6",
-        "debug": "^2.1.1",
-        "doctrine": "^0.7.0",
-        "escape-string-regexp": "^1.0.2",
-        "escope": "^3.2.0",
-        "espree": "^2.2.4",
-        "estraverse": "^4.1.1",
-        "estraverse-fb": "^1.3.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^1.1.1",
-        "glob": "^5.0.14",
-        "globals": "^8.11.0",
-        "handlebars": "^4.0.0",
-        "inquirer": "^0.11.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.2.5",
-        "json-stable-stringify": "^1.0.0",
-        "lodash.clonedeep": "^3.0.1",
-        "lodash.merge": "^3.3.2",
-        "lodash.omit": "^3.1.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.1",
-        "optionator": "^0.6.0",
-        "path-is-absolute": "^1.0.0",
-        "path-is-inside": "^1.0.1",
-        "shelljs": "^0.5.3",
-        "strip-json-comments": "~1.0.1",
-        "text-table": "~0.2.0",
-        "to-double-quotes": "^2.0.0",
-        "to-single-quotes": "^2.0.0",
-        "user-home": "^2.0.0",
-        "xml-escape": "~1.0.0"
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "doctrine": "0.7.2",
+        "escape-string-regexp": "1.0.5",
+        "escope": "3.6.0",
+        "espree": "2.2.5",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.2",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "5.0.15",
+        "globals": "8.18.0",
+        "handlebars": "4.0.12",
+        "inquirer": "0.11.4",
+        "is-my-json-valid": "2.19.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify": "1.0.1",
+        "lodash.clonedeep": "3.0.2",
+        "lodash.merge": "3.3.2",
+        "lodash.omit": "3.1.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "optionator": "0.6.0",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "text-table": "0.2.0",
+        "to-double-quotes": "2.0.0",
+        "to-single-quotes": "2.0.1",
+        "user-home": "2.0.0",
+        "xml-escape": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -1146,11 +1146,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1191,7 +1191,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -1218,8 +1218,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46"
       }
     },
     "exit-hook": {
@@ -1246,8 +1246,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-entry-cache": {
@@ -1256,8 +1256,8 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.2",
+        "object-assign": "4.1.1"
       }
     },
     "find-root": {
@@ -1272,10 +1272,10 @@
       "integrity": "sha512-KByBY8c98sLUAGpnmjEdWTrtrLZRtZdwds+kAL/ciFXTCb7AZgqKsAnVnYFQj1hxepwO8JKN/8AsRWwLq+RK0A==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^3.0.0",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "3.0.0",
+        "graceful-fs": "4.1.15",
+        "write": "0.2.1"
       }
     },
     "foreach": {
@@ -1290,10 +1290,10 @@
       "integrity": "sha1-WWbe6V+zXSopsS0vJRaLFyJeS2w=",
       "dev": true,
       "requires": {
-        "acorn": "^1.0.3",
-        "foreach": "^2.0.5",
+        "acorn": "1.2.2",
+        "foreach": "2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
+        "object-keys": "1.0.12"
       },
       "dependencies": {
         "acorn": {
@@ -1328,7 +1328,7 @@
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.2"
+        "is-property": "1.0.2"
       }
     },
     "generate-object-property": {
@@ -1337,7 +1337,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-stdin": {
@@ -1352,12 +1352,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
@@ -1372,11 +1372,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.3",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -1399,10 +1399,10 @@
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "async": "2.6.1",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.4.9"
       }
     },
     "has-ansi": {
@@ -1411,7 +1411,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "home-or-tmp": {
@@ -1420,8 +1420,8 @@
       "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "^1.0.1",
-        "user-home": "^1.1.1"
+        "os-tmpdir": "1.0.2",
+        "user-home": "1.1.1"
       },
       "dependencies": {
         "user-home": {
@@ -1438,7 +1438,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -1453,8 +1453,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1475,19 +1475,19 @@
       "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^1.0.1",
-        "figures": "^1.3.5",
-        "lodash": "^3.3.1",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "1.1.1",
+        "figures": "1.7.0",
+        "lodash": "3.10.1",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       },
       "dependencies": {
         "lodash": {
@@ -1504,7 +1504,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -1525,7 +1525,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -1534,7 +1534,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-integer": {
@@ -1543,7 +1543,7 @@
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "is-my-ip-valid": {
@@ -1558,11 +1558,11 @@
       "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.3.1",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-path-cwd": {
@@ -1577,7 +1577,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -1586,7 +1586,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-property": {
@@ -1619,10 +1619,10 @@
       "integrity": "sha512-qVNq7ZZ7ZbLdzorvSlRDadS0Rh5oyItaE95v6I4wbbuSiijxn7SnnsV6dvKlcXuO2jX7lK8tn9fBulx34K/Ejg==",
       "dev": true,
       "requires": {
-        "config-chain": "~1.1.5",
-        "editorconfig": "^0.15.0",
-        "mkdirp": "~0.5.0",
-        "nopt": "~4.0.1"
+        "config-chain": "1.1.12",
+        "editorconfig": "0.15.2",
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1"
       }
     },
     "js-tokens": {
@@ -1637,8 +1637,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       },
       "dependencies": {
         "esprima": {
@@ -1661,7 +1661,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json5": {
@@ -1688,7 +1688,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -1703,7 +1703,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "leven": {
@@ -1718,8 +1718,8 @@
       "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.0",
-        "type-check": "~0.3.1"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lodash": {
@@ -1752,8 +1752,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._baseclone": {
@@ -1762,12 +1762,12 @@
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "dev": true,
       "requires": {
-        "lodash._arraycopy": "^3.0.0",
-        "lodash._arrayeach": "^3.0.0",
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basefor": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._baseassign": "3.2.0",
+        "lodash._basefor": "3.0.3",
+        "lodash.isarray": "3.0.4",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._basecopy": {
@@ -1782,9 +1782,9 @@
       "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
       "dev": true,
       "requires": {
-        "lodash._baseindexof": "^3.0.0",
-        "lodash._cacheindexof": "^3.0.0",
-        "lodash._createcache": "^3.0.0"
+        "lodash._baseindexof": "3.1.0",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2"
       }
     },
     "lodash._baseflatten": {
@@ -1793,8 +1793,8 @@
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
       "dev": true,
       "requires": {
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash._basefor": {
@@ -1827,9 +1827,9 @@
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
-        "lodash._bindcallback": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
       }
     },
     "lodash._createcache": {
@@ -1838,7 +1838,7 @@
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0"
+        "lodash._getnative": "3.9.1"
       }
     },
     "lodash._getnative": {
@@ -1865,8 +1865,8 @@
       "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
       "dev": true,
       "requires": {
-        "lodash._basefor": "^3.0.0",
-        "lodash.keysin": "^3.0.0"
+        "lodash._basefor": "3.0.3",
+        "lodash.keysin": "3.0.8"
       }
     },
     "lodash.clonedeep": {
@@ -1875,8 +1875,8 @@
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "dev": true,
       "requires": {
-        "lodash._baseclone": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0"
+        "lodash._baseclone": "3.3.0",
+        "lodash._bindcallback": "3.0.1"
       }
     },
     "lodash.isarguments": {
@@ -1897,9 +1897,9 @@
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
       "dev": true,
       "requires": {
-        "lodash._basefor": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.keysin": "^3.0.0"
+        "lodash._basefor": "3.0.3",
+        "lodash.isarguments": "3.1.0",
+        "lodash.keysin": "3.0.8"
       }
     },
     "lodash.istypedarray": {
@@ -1914,9 +1914,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.keysin": {
@@ -1925,8 +1925,8 @@
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
       "dev": true,
       "requires": {
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.merge": {
@@ -1935,17 +1935,17 @@
       "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
       "dev": true,
       "requires": {
-        "lodash._arraycopy": "^3.0.0",
-        "lodash._arrayeach": "^3.0.0",
-        "lodash._createassigner": "^3.0.0",
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.isplainobject": "^3.0.0",
-        "lodash.istypedarray": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.keysin": "^3.0.0",
-        "lodash.toplainobject": "^3.0.0"
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4",
+        "lodash.isplainobject": "3.2.0",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2",
+        "lodash.keysin": "3.0.8",
+        "lodash.toplainobject": "3.0.0"
       }
     },
     "lodash.omit": {
@@ -1954,14 +1954,14 @@
       "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
       "dev": true,
       "requires": {
-        "lodash._arraymap": "^3.0.0",
-        "lodash._basedifference": "^3.0.0",
-        "lodash._baseflatten": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash._pickbyarray": "^3.0.0",
-        "lodash._pickbycallback": "^3.0.0",
-        "lodash.keysin": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
+        "lodash._arraymap": "3.0.0",
+        "lodash._basedifference": "3.0.3",
+        "lodash._baseflatten": "3.1.4",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._pickbyarray": "3.0.2",
+        "lodash._pickbycallback": "3.0.0",
+        "lodash.keysin": "3.0.8",
+        "lodash.restparam": "3.6.1"
       }
     },
     "lodash.restparam": {
@@ -1976,8 +1976,8 @@
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keysin": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash.keysin": "3.0.8"
       }
     },
     "longest": {
@@ -1992,7 +1992,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "js-tokens": {
@@ -2009,8 +2009,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "minimatch": {
@@ -2019,7 +2019,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2063,7 +2063,7 @@
       "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
       "dev": true,
       "requires": {
-        "strip-indent": "^1.0.0"
+        "strip-indent": "1.0.1"
       }
     },
     "mute-stream": {
@@ -2084,8 +2084,8 @@
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
       }
     },
     "npm-path": {
@@ -2094,7 +2094,7 @@
       "integrity": "sha1-BHSuAEGcMn1UcBt88s0F3Ii+EUA=",
       "dev": true,
       "requires": {
-        "which": "^1.2.4"
+        "which": "1.3.1"
       }
     },
     "npm-run": {
@@ -2103,12 +2103,12 @@
       "integrity": "sha1-KN/ArV4uRv4ISOK9WN3wAue3PBU=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.1",
-        "npm-path": "^1.0.1",
-        "npm-which": "^2.0.0",
-        "serializerr": "^1.0.1",
-        "spawn-sync": "^1.0.5",
-        "sync-exec": "^0.5.0"
+        "minimist": "1.2.0",
+        "npm-path": "1.1.0",
+        "npm-which": "2.0.0",
+        "serializerr": "1.0.3",
+        "spawn-sync": "1.0.15",
+        "sync-exec": "0.5.0"
       }
     },
     "npm-which": {
@@ -2117,9 +2117,9 @@
       "integrity": "sha1-DEaYIWC3gwk2YdHQG9RJbS/qu6w=",
       "dev": true,
       "requires": {
-        "commander": "^2.2.0",
-        "npm-path": "^1.0.0",
-        "which": "^1.0.5"
+        "commander": "2.17.1",
+        "npm-path": "1.1.0",
+        "which": "1.3.1"
       }
     },
     "number-is-nan": {
@@ -2146,7 +2146,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -2161,8 +2161,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -2179,12 +2179,12 @@
       "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~1.0.6",
-        "levn": "~0.2.5",
-        "prelude-ls": "~1.1.1",
-        "type-check": "~0.3.1",
-        "wordwrap": "~0.0.2"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "1.0.7",
+        "levn": "0.2.5",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "0.0.3"
       }
     },
     "os-homedir": {
@@ -2199,7 +2199,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-shim": {
@@ -2220,8 +2220,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "output-file-sync": {
@@ -2230,9 +2230,9 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.4",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.0"
+        "graceful-fs": "4.1.15",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "p-map": {
@@ -2283,7 +2283,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-config": {
@@ -2292,9 +2292,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "find-root": {
@@ -2353,13 +2353,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readline2": {
@@ -2368,8 +2368,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -2380,9 +2380,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.8.12",
-        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.8",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "ast-types": {
@@ -2417,12 +2417,12 @@
       "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
       "dev": true,
       "requires": {
-        "commoner": "~0.10.3",
-        "defs": "~1.1.0",
-        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-        "private": "~0.1.5",
+        "commoner": "0.10.8",
+        "defs": "1.1.1",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.8",
         "recast": "0.10.33",
-        "through": "~2.3.8"
+        "through": "2.3.8"
       },
       "dependencies": {
         "esprima-fb": {
@@ -2445,11 +2445,11 @@
       "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
       "dev": true,
       "requires": {
-        "esprima": "^2.6.0",
-        "recast": "^0.10.10",
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "esprima": "2.7.3",
+        "recast": "0.10.33",
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       },
       "dependencies": {
         "esprima": {
@@ -2472,7 +2472,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "repeat-string": {
@@ -2487,7 +2487,7 @@
       "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "resolve": {
@@ -2496,7 +2496,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "restore-cursor": {
@@ -2505,8 +2505,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "right-align": {
@@ -2515,7 +2515,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -2524,7 +2524,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       }
     },
     "rocambole": {
@@ -2533,7 +2533,7 @@
       "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
       "dev": true,
       "requires": {
-        "esprima": "^2.1"
+        "esprima": "2.7.3"
       },
       "dependencies": {
         "esprima": {
@@ -2550,9 +2550,9 @@
       "integrity": "sha1-oYokl3ygQAuGHapGMehh3LUtCFw=",
       "dev": true,
       "requires": {
-        "debug": "^2.1.3",
-        "mout": "^0.11.0",
-        "rocambole-token": "^1.2.1"
+        "debug": "2.6.9",
+        "mout": "0.11.1",
+        "rocambole-token": "1.2.1"
       },
       "dependencies": {
         "mout": {
@@ -2569,9 +2569,9 @@
       "integrity": "sha1-A2IVFbQ7RyHJflocG8paA2Y2jy8=",
       "dev": true,
       "requires": {
-        "debug": "^2.1.3",
-        "rocambole-token": "^1.2.1",
-        "semver": "^4.3.1"
+        "debug": "2.6.9",
+        "rocambole-token": "1.2.1",
+        "semver": "4.3.6"
       }
     },
     "rocambole-node": {
@@ -2592,9 +2592,9 @@
       "integrity": "sha1-YzMJSSVrKZQfWbGQRZ+ZnGsdO/k=",
       "dev": true,
       "requires": {
-        "debug": "^2.1.3",
-        "repeat-string": "^1.5.0",
-        "rocambole-token": "^1.2.1"
+        "debug": "2.6.9",
+        "repeat-string": "1.6.1",
+        "rocambole-token": "1.2.1"
       }
     },
     "run-async": {
@@ -2603,7 +2603,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "run-parallel": {
@@ -2642,7 +2642,7 @@
       "integrity": "sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=",
       "dev": true,
       "requires": {
-        "protochain": "^1.0.5"
+        "protochain": "1.0.5"
       }
     },
     "shebang-regex": {
@@ -2702,7 +2702,7 @@
           "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -2713,8 +2713,8 @@
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
+        "concat-stream": "1.6.2",
+        "os-shim": "0.1.3"
       }
     },
     "sprintf-js": {
@@ -2737,10 +2737,10 @@
       "requires": {
         "eslint-config-standard": "4.4.0",
         "eslint-config-standard-react": "1.2.1",
-        "eslint-plugin-react": "^3.9.0",
-        "eslint-plugin-standard": "^1.3.1",
-        "standard-engine": "^2.0.4",
-        "standard-format": "^1.3.3"
+        "eslint-plugin-react": "3.16.1",
+        "eslint-plugin-standard": "1.3.3",
+        "standard-engine": "2.2.5",
+        "standard-format": "1.6.10"
       }
     },
     "standard-engine": {
@@ -2749,16 +2749,16 @@
       "integrity": "sha1-ornUQZ9kiiIbjReCP7dFQG83w04=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.2",
-        "deglob": "^1.0.0",
-        "dezalgo": "^1.0.2",
+        "defaults": "1.0.3",
+        "deglob": "1.1.2",
+        "dezalgo": "1.0.3",
         "eslint": "1.9.0",
-        "find-root": "^0.1.1",
-        "get-stdin": "^4.0.1",
-        "minimist": "^1.1.0",
-        "multiline": "^1.0.2",
-        "pkg-config": "^1.0.1",
-        "xtend": "^4.0.0"
+        "find-root": "0.1.2",
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0",
+        "multiline": "1.0.2",
+        "pkg-config": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "standard-format": {
@@ -2767,15 +2767,15 @@
       "integrity": "sha1-sYPI+DfI05OHmPPQlD5dgHoboD8=",
       "dev": true,
       "requires": {
-        "deglob": "^1.0.0",
-        "esformatter": "^0.8.1",
-        "esformatter-eol-last": "^1.0.0",
-        "esformatter-jsx": "^2.0.11",
-        "esformatter-literal-notation": "^1.0.0",
-        "esformatter-quotes": "^1.0.0",
-        "esformatter-semicolon-first": "^1.1.0",
-        "esformatter-spaced-lined-comment": "^2.0.0",
-        "minimist": "^1.1.0",
+        "deglob": "1.1.2",
+        "esformatter": "0.8.2",
+        "esformatter-eol-last": "1.0.0",
+        "esformatter-jsx": "2.3.11",
+        "esformatter-literal-notation": "1.0.1",
+        "esformatter-quotes": "1.1.0",
+        "esformatter-semicolon-first": "1.2.0",
+        "esformatter-spaced-lined-comment": "2.0.1",
+        "minimist": "1.2.0",
         "stdin": "0.0.1"
       }
     },
@@ -2791,9 +2791,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string.prototype.endswith": {
@@ -2808,7 +2808,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringmap": {
@@ -2829,7 +2829,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-indent": {
@@ -2838,7 +2838,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -2913,7 +2913,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -2929,8 +2929,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1"
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
       }
     },
     "uniq": {
@@ -2945,7 +2945,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "util-deprecate": {
@@ -2960,7 +2960,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "window-size": {
@@ -2987,7 +2987,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "xml-escape": {
@@ -3020,12 +3020,12 @@
       "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
       "dev": true,
       "requires": {
-        "camelcase": "^1.2.1",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "os-locale": "^1.4.0",
-        "window-size": "^0.1.2",
-        "y18n": "^3.2.0"
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
       }
     }
   }

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -184,6 +184,31 @@ describe('ToggleQuotes', () => {
         })
       })
     })
+
+    describe('when the string contains escaped characters', () => {
+      it ('does not remove them if they are at the end of the line', () => {
+        editor.setText(`'\\\\'`) // == `'\\'`
+        editor.setCursorBufferPosition([0, 2])
+        toggleQuotes(editor)
+        expect(editor.getText()).toBe(`"\\\\"`) // == `"\\"`
+      })
+
+      describe('when there is an escaped quote mark', () => {
+        it ('unescapes if it is the original delim', () => {
+          editor.setText(`'\\\''`) // == `'\''`
+          editor.setCursorBufferPosition([0, 3])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe(`"'"`)
+        })
+
+        it ('correctly counts escapes', () => {
+          editor.setText(`'\\\\\\\''`) // == `'\\\''`
+          editor.setCursorBufferPosition([0, 4])
+          toggleQuotes(editor)
+          expect(editor.getText()).toBe(`"\\\\'"`) // == `"\\'"`
+        })
+      })
+    })
   })
 
   describe('toggleQuotes(editor) python', () => {

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -186,7 +186,7 @@ describe('ToggleQuotes', () => {
     })
 
     describe('when the string contains escaped characters', () => {
-      it ('does not remove them if they are at the end of the line', () => {
+      it('does not remove them if they are at the end of the line', () => {
         editor.setText(`'\\\\'`)
         editor.setCursorBufferPosition([0, 2])
         toggleQuotes(editor)
@@ -194,14 +194,14 @@ describe('ToggleQuotes', () => {
       })
 
       describe('when there is an escaped quote mark', () => {
-        it ('unescapes if it is the original delim', () => {
+        it('unescapes if it is the original delim', () => {
           editor.setText(`'\\\''`)
           editor.setCursorBufferPosition([0, 3])
           toggleQuotes(editor)
           expect(editor.getText()).toBe(`"'"`)
         })
 
-        it ('correctly counts escapes', () => {
+        it('correctly counts escapes', () => {
           editor.setText(`'\\\\\\\''`)
           editor.setCursorBufferPosition([0, 4])
           toggleQuotes(editor)

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -185,28 +185,38 @@ describe('ToggleQuotes', () => {
       })
     })
 
-    describe('when the string contains escaped characters', () => {
-      it('does not remove them if they are at the end of the line', () => {
-        editor.setText(`'\\\\'`)
+    describe('when handling escaped characters', () => {
+      it('ignores them if they do not match the previous quote character', () => {
+        editor.setText(`'\\\\ \\" \\a'`)
         editor.setCursorBufferPosition([0, 2])
         toggleQuotes(editor)
-        expect(editor.getText()).toBe(`"\\\\"`)
+        expect(editor.getText()).toBe(`"\\\\ \\" \\a"`)
       })
 
-      describe('when there is an escaped quote mark', () => {
-        it('unescapes if it is the original delim', () => {
-          editor.setText(`'\\\''`)
-          editor.setCursorBufferPosition([0, 3])
-          toggleQuotes(editor)
-          expect(editor.getText()).toBe(`"'"`)
-        })
+      it('unescapes any escaped previous quote characters', () => {
+        editor.setText(`'don\\'t can\\'t'`)
+        editor.setCursorBufferPosition([0, 1])
+        toggleQuotes(editor)
+        expect(editor.getText()).toBe(`"don't can't"`)
+      })
 
-        it('correctly counts escapes', () => {
-          editor.setText(`'\\\\\\\''`)
-          editor.setCursorBufferPosition([0, 4])
-          toggleQuotes(editor)
-          expect(editor.getText()).toBe(`"\\\\'"`)
-        })
+      it('escapes any unescaped next quote characters', () => {
+        editor.setText(`'"Hello world"'`)
+        editor.setCursorBufferPosition([0, 1])
+        toggleQuotes(editor)
+        expect(editor.getText()).toBe(`"\\"Hello world\\""`)
+      })
+
+      it('counts escapes correctly', () => {
+        editor.setText(`'\\\\\\''`) // escaped \ + escaped '
+        editor.setCursorBufferPosition([0, 1])
+        toggleQuotes(editor)
+        expect(editor.getText()).toBe(`"\\\\'"`)
+
+        editor.setText(`'\\\\"'`) // escaped \ + regular "
+        editor.setCursorBufferPosition([0, 1])
+        toggleQuotes(editor)
+        expect(editor.getText()).toBe(`"\\\\\\""`)
       })
     })
   })

--- a/spec/toggle-quotes-spec.js
+++ b/spec/toggle-quotes-spec.js
@@ -187,25 +187,25 @@ describe('ToggleQuotes', () => {
 
     describe('when the string contains escaped characters', () => {
       it ('does not remove them if they are at the end of the line', () => {
-        editor.setText(`'\\\\'`) // == `'\\'`
+        editor.setText(`'\\\\'`)
         editor.setCursorBufferPosition([0, 2])
         toggleQuotes(editor)
-        expect(editor.getText()).toBe(`"\\\\"`) // == `"\\"`
+        expect(editor.getText()).toBe(`"\\\\"`)
       })
 
       describe('when there is an escaped quote mark', () => {
         it ('unescapes if it is the original delim', () => {
-          editor.setText(`'\\\''`) // == `'\''`
+          editor.setText(`'\\\''`)
           editor.setCursorBufferPosition([0, 3])
           toggleQuotes(editor)
           expect(editor.getText()).toBe(`"'"`)
         })
 
         it ('correctly counts escapes', () => {
-          editor.setText(`'\\\\\\\''`) // == `'\\\''`
+          editor.setText(`'\\\\\\\''`)
           editor.setCursorBufferPosition([0, 4])
           toggleQuotes(editor)
-          expect(editor.getText()).toBe(`"\\\\'"`) // == `"\\'"`
+          expect(editor.getText()).toBe(`"\\\\'"`)
         })
       })
     })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This replaces the part that goes through and escapes / unescapes existing quote characters.

Previously, it looked for `\'` and removed the `\`, and saw `"` and escaped it to `\"`. This doesn't work when characters are escaped though, because it would incorrectly change `\\'`

Now it does a single pass using a regex that grabs both cases. Based on the match it made, it will
1) Escape if it's a lone quote we are about to change the delims to
2) Unescape it if it's an escaped old quote character. 
   - I think this behaviour should be configurable, but is not in the scope of this PR.
3) Ignore it if it's an escaped anything else

As the replace function resumes at the end of a previous match, the "ignore it if it's an escaped anything else" rule lets us count escapes correctly.

### Alternate Designs

Iterating the string may have been better, but I still found regex easier to work with.

### Benefits

No longer does weird behaviour when escapes are in a string.

### Possible Drawbacks

It still assumes the escape character is `\`. Again, that's existing behaviour and needs it's own PR.

### Applicable Issues

Fixes https://github.com/atom/toggle-quotes/issues/33